### PR TITLE
Update PHP requirement to 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name":"tsingsun/yii2-graphql",
     "description":"facebook graphql server side for yii2 php framework",
-    "keyword":["yii2","graphql"],    
+    "keywords": ["yii2", "graphql"],
     "type":"yii2-extension",
     "license": "BSD-3-Clause",
     "authors":[
@@ -12,14 +12,14 @@
     ],
     "minimum-stability":"dev",
     "require":{
-        "php": ">=5.6.0",
+        "php": ">=7.4.0",
         "yiisoft/yii2":"~2.0.10",
         "webonyx/graphql-php": "^0.13.0",
         "ecodev/graphql-upload": "^4.0.0",
-        "zendframework/zend-diactoros": "^2.1"
+        "laminas/laminas-diactoros": "^2.13"
     },
     "require-dev":{
-        "phpunit/phpunit": "4.8.*"
+        "phpunit/phpunit": "^7.5"
     },
     "autoload":{
         "psr-4":{

--- a/src/GraphQLAction.php
+++ b/src/GraphQLAction.php
@@ -13,7 +13,7 @@ use yii\base\Action;
 use yii\web\Response;
 use yii\base\InvalidParamException;
 use GraphQL\Upload\UploadMiddleware;
-use Zend\Diactoros\ServerRequestFactory;
+use Laminas\Diactoros\ServerRequestFactory;
 
 /**
  * GraphQLAction implements the access method of the graph server and returns the query results in the JSON format

--- a/src/exceptions/ValidatorException.php
+++ b/src/exceptions/ValidatorException.php
@@ -23,7 +23,7 @@ class ValidatorException extends Exception
      * @param int $code
      * @param Throwable|null $previous
      */
-    public function __construct($model, $code = 0, Throwable $previous = null)
+    public function __construct($model, $code = 0, ?Throwable $previous = null)
     {
         parent::__construct("model {$model->formName()} validate false", $code, $previous);
         $this->formatModelErrors($model);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -18,8 +18,9 @@ use yiiunit\extensions\graphql\objects\query\UserQuery;
 use yiiunit\extensions\graphql\objects\query\ViewerQuery;
 use yiiunit\extensions\graphql\objects\types\ExampleType;
 use yiiunit\extensions\graphql\objects\types\StoryType;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 
-abstract class TestCase extends \PHPUnit_Framework_TestCase
+abstract class TestCase extends BaseTestCase
 {
     protected $queries;
     protected $data;


### PR DESCRIPTION
## Summary
- bump the PHP requirement to 7.4
- update PHPUnit dev dependency
- adjust tests to use namespaced PHPUnit base class

## Testing
- `composer validate --strict --no-check-all`
- `php -l src/GraphQLAction.php`
- `php -l src/exceptions/ValidatorException.php`
- `find src -name '*.php' -print0 | xargs -0 -n1 php -l`
- `find tests -name '*.php' -print0 | xargs -0 -n1 php -l`
- `composer install --no-interaction` *(fails: CONNECT tunnel failed)*
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_6877dca129dc83318450996b9a7d4758