### PR TITLE
Handle missing schemas with SchemaNotFound

### DIFF
--- a/src/ErrorFormatter.php
+++ b/src/ErrorFormatter.php
@@ -5,6 +5,7 @@ namespace yii\graphql;
 use Yii;
 use GraphQL\Error\Error;
 use GraphQL\Error\FormattedError;
+use yii\graphql\exceptions\SchemaNotFound;
 use yii\graphql\exceptions\ValidatorException;
 use yii\web\HttpException;
 
@@ -21,6 +22,9 @@ class ErrorFormatter
             Yii::$app->getErrorHandler()->logException($previous);
             if ($previous instanceof ValidatorException) {
                 return $previous->formatErrors;
+            }
+            if ($previous instanceof SchemaNotFound) {
+                return ['code' => $previous->getCode() ?: 404, 'message' => $previous->getMessage()];
             }
             if ($previous instanceof HttpException) {
                 return ['code' => $previous->statusCode, 'message' => $previous->getMessage()];

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -22,6 +22,7 @@ use GraphQL\Validator\DocumentValidator;
 use GraphQL\Validator\Rules\QueryComplexity;
 use Yii;
 use yii\base\InvalidConfigException;
+use yii\graphql\exceptions\SchemaNotFound;
 use yii\graphql\exceptions\TypeNotFound;
 use yii\helpers\ArrayHelper;
 
@@ -110,10 +111,16 @@ class GraphQL
         if ($schema instanceof Schema) {
             return $schema;
         }
+        if ($schema === null && empty($this->queries) && empty($this->mutations)) {
+            throw new SchemaNotFound('Schema not defined.', 404);
+        }
         if ($schema === null) {
             list($schemaQuery, $schemaMutation, $schemaTypes) = [$this->queries, $this->mutations, $this->types];
         } else {
             list($schemaQuery, $schemaMutation, $schemaTypes) = $schema;
+        }
+        if (empty($schemaQuery) && empty($schemaMutation)) {
+            throw new SchemaNotFound('Schema not found for requested operation.', 404);
         }
         $types = [];
         if (sizeof($schemaTypes)) {

--- a/src/exceptions/SchemaNotFound.php
+++ b/src/exceptions/SchemaNotFound.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace yii\graphql\exception;
+namespace yii\graphql\exceptions;
 
 use Exception;
 

--- a/tests/GraphQLActionTest.php
+++ b/tests/GraphQLActionTest.php
@@ -49,6 +49,9 @@ class GraphQLActionTest extends TestCase
         $ret = $action->runWithParams([]);
         $this->assertNotEmpty($ret);
         $this->assertArrayHasKey('errors', $ret);
+        $this->assertArrayHasKey('code', $ret['errors'][0]);
+        $this->assertSame(404, $ret['errors'][0]['code']);
+        $this->assertSame('Schema not found for requested operation.', $ret['errors'][0]['message']);
     }
 
     function testAuthBehavior()

--- a/tests/GraphQLTest.php
+++ b/tests/GraphQLTest.php
@@ -5,6 +5,7 @@ namespace yiiunit\extensions\graphql;
 use GraphQL\Type\Schema;
 use GraphQL\Type\Definition\ObjectType;
 use yii\graphql\GraphQL;
+use yii\graphql\exceptions\SchemaNotFound;
 use yiiunit\extensions\graphql\objects\types\ExampleType;
 use yiiunit\extensions\graphql\objects\types\ResultItemType;
 
@@ -93,5 +94,13 @@ class GraphQLTest extends TestCase
         $query = $this->queries['multiQuery'];
         $ret = $this->graphql->parseRequestQuery($query);
         $this->assertNotEmpty($ret);
+    }
+
+    public function testSchemaNotFoundIsThrownWhenSchemaIsEmpty()
+    {
+        $graphql = new GraphQL();
+
+        $this->expectException(SchemaNotFound::class);
+        $graphql->buildSchema();
     }
 }


### PR DESCRIPTION
## Summary
- update SchemaNotFound to use the exceptions namespace and throw it when schema data is missing
- catch missing schema errors in GraphQLAction and format them for clients
- adjust tests to cover missing schema handling and clearer error messaging

## Testing
- Not run (phpunit binary not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69259086ad5483318f74f3293b8a18a9)