### PR TITLE
Add GraphQL action tests for variables and raw body

### DIFF
--- a/tests/GraphQLActionTest.php
+++ b/tests/GraphQLActionTest.php
@@ -121,4 +121,41 @@ class GraphQLActionTest extends TestCase
         $ret = $controller->runAction('index');
         $this->assertNotEmpty($ret);
     }
+
+    function testJsonStringVariablesAreDecoded()
+    {
+        $query = <<<GRAPHQL
+query user($id: ID!) {
+    user(id: $id) {
+        id
+        email
+    }
+}
+GRAPHQL;
+
+        $_GET = [
+            'query' => $query,
+            'variables' => json_encode(['id' => '2']),
+        ];
+
+        $result = $this->controller->runAction('index');
+
+        $this->assertSame('2', $result['data']['user']['id']);
+        $this->assertSame('jane@example.com', $result['data']['user']['email']);
+    }
+
+    function testRawBodyIsUsedWhenBodyParamsAreEmpty()
+    {
+        $request = \Yii::$app->request;
+        $request->setMethod('POST');
+        $request->setBodyParams([]);
+        $request->setRawBody($this->queries['singleObject']);
+
+        $result = $this->controller->createAction('index')->runWithParams([]);
+
+        $this->assertSame('2', $result['data']['user']['id']);
+        $this->assertSame('jane@example.com', $result['data']['user']['email']);
+        $this->assertArrayHasKey('url', $result['data']['user']['photo']);
+        $this->assertStringContainsString('/images/user/2-ICON.jpg', $result['data']['user']['photo']['url']);
+    }
 }

--- a/tests/GraphQLActionTest.php
+++ b/tests/GraphQLActionTest.php
@@ -124,7 +124,7 @@ class GraphQLActionTest extends TestCase
 
     function testJsonStringVariablesAreDecoded()
     {
-        $query = <<<GRAPHQL
+        $query = <<<'GRAPHQL'
 query user($id: ID!) {
     user(id: $id) {
         id
@@ -147,11 +147,15 @@ GRAPHQL;
     function testRawBodyIsUsedWhenBodyParamsAreEmpty()
     {
         $request = \Yii::$app->request;
-        $request->setMethod('POST');
+        $previousRequestMethod = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+        $_SERVER['REQUEST_METHOD'] = 'POST';
         $request->setBodyParams([]);
         $request->setRawBody($this->queries['singleObject']);
 
         $result = $this->controller->createAction('index')->runWithParams([]);
+
+        $_SERVER['REQUEST_METHOD'] = $previousRequestMethod;
+        $request->setRawBody('');
 
         $this->assertSame('2', $result['data']['user']['id']);
         $this->assertSame('jane@example.com', $result['data']['user']['email']);

--- a/tests/GraphQLActionTest.php
+++ b/tests/GraphQLActionTest.php
@@ -160,6 +160,6 @@ GRAPHQL;
         $this->assertSame('2', $result['data']['user']['id']);
         $this->assertSame('jane@example.com', $result['data']['user']['email']);
         $this->assertArrayHasKey('url', $result['data']['user']['photo']);
-        $this->assertStringContainsString('/images/user/2-ICON.jpg', $result['data']['user']['photo']['url']);
+        $this->assertStringContainsString('/images/user/2-icon.jpg', $result['data']['user']['photo']['url']);
     }
 }


### PR DESCRIPTION
## Summary
- add a GraphQLAction test that exercises JSON string variables through the index action and asserts returned data
- add coverage to ensure raw request bodies are executed when body params are empty, validating returned payload content

## Testing
- not run (phpunit unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925b26c1ff483318c4ec860f73189b7)